### PR TITLE
Add options to decrease load on collector; Add statusTraceIDRatioSampler

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@
 * health check fix metrics exposure
 * change health check metrics names: `up` => `service.health`, `up.status` => `service.health.status`
 * Help figure out where "use null Telemetry" usage. Like tel.FromCtx(context.Background()).Debug()
+* add options to decrease load on collector (log message size, duplication of information for span and log, rate of flush, etc.)
 
 == v2.2.3
 * Preserve span instance in telemetry during span creation - this should help us to continue traces when it's not possible pass context of it

--- a/config_test.go
+++ b/config_test.go
@@ -9,87 +9,15 @@ import (
 	"testing"
 )
 
+const (
+	envOtelTlsCA = "OTEL_COLLECTOR_TLS_CA_CERT"
+	envOtelCert  = "OTEL_COLLECTOR_TLS_CLIENT_CERT"
+	envOtelKey   = "OTEL_COLLECTOR_TLS_CLIENT_KEY"
+)
+
 func TestGetConfigFromEnv(t *testing.T) {
 	// TODO: Add test cases.
 	_ = GetConfigFromEnv()
-}
-
-func TestBoolOverwrite(t *testing.T) {
-	const (
-		envBoolExistTrue    = "ENV_BOOL_TRUE"
-		envBoolExistFalse   = "ENV_BOOL_FALSE"
-		envBoolExistInvalid = "ENV_BOOL_INVALID"
-		envBoolUndefined    = "ENV_BOOL_UNDEFINED"
-	)
-
-	const (
-		strBoolTrue    = "true"
-		strBoolFalse   = "false"
-		strBoolInvalid = "invalid-value"
-	)
-
-	_ = os.Setenv(envBoolExistTrue, strBoolTrue)
-	_ = os.Setenv(envBoolExistFalse, strBoolFalse)
-	_ = os.Setenv(envBoolExistInvalid, strBoolInvalid)
-
-	{
-		var envBoolTrueValue = true
-		bl(envBoolExistTrue, &envBoolTrueValue)
-		//No changes TRUE
-		if envBoolTrueValue != true {
-			t.Error("TRUE_EXIST_TRUE")
-		}
-
-		var envBoolFalseValue = false
-		bl(envBoolExistTrue, &envBoolFalseValue)
-		//Overwrite FALSE -> TRUE
-		if envBoolFalseValue != true {
-			t.Error("FALSE_EXIST_TRUE")
-		}
-	} //EXIST_TRUE
-	{
-		var envBoolTrueValue = true
-		bl(envBoolExistFalse, &envBoolTrueValue)
-		//Overwrite TRUE -> FALSE
-		if envBoolTrueValue != false {
-			t.Error("TRUE_EXIST_FALSE")
-		}
-
-		var envBoolFalseValue = false
-		bl(envBoolExistFalse, &envBoolFalseValue)
-		//No changes FALSE
-		if envBoolFalseValue != false {
-			t.Error("TRUE_EXIST_FALSE")
-		}
-	} //EXIST_FALSE
-	{
-		var envBoolTrueValue = true
-		bl(envBoolExistInvalid, &envBoolTrueValue)
-		//No changes. Failed overwrite TRUE -> INVALID
-		if envBoolTrueValue != true {
-			t.Error("TRUE_EXIST_INVALID")
-		}
-		var envBoolFalseValue = false
-		bl(envBoolExistInvalid, &envBoolFalseValue)
-		//No changes. Failed overwrite FALSE -> INVALID
-		if envBoolFalseValue != false {
-			t.Error("FALSE_EXIST_INVALID")
-		}
-	} //EXIST_INVALID
-	{
-		var envBoolTrueValue = true
-		bl(envBoolUndefined, &envBoolTrueValue)
-		//No changes. Env not found for overwrite
-		if envBoolTrueValue != true {
-			t.Error("TRUE_UNDEFINED")
-		}
-		var envBoolFalseValue = false
-		bl(envBoolUndefined, &envBoolFalseValue)
-		//No changes. Env not found for overwrite
-		if envBoolFalseValue != false {
-			t.Error("FALSE_UNDEFINED")
-		}
-	} //UNDEFINED
 }
 
 func certPath(file string) string {
@@ -115,7 +43,7 @@ func Test_telemetry_TLS(t *testing.T) {
 	loadClientCerts(t)
 	cfg := GetConfigFromEnv()
 
-	assert.True(t, true, len(cfg.OtelConfig.Raw.CA) > 0)
-	assert.True(t, true, len(cfg.OtelConfig.Raw.Key) > 0)
-	assert.True(t, true, len(cfg.OtelConfig.Raw.Cert) > 0)
+	assert.NotEmpty(t, cfg.OtelConfig.Raw.CA)
+	assert.NotEmpty(t, cfg.OtelConfig.Raw.Key)
+	assert.NotEmpty(t, cfg.OtelConfig.Raw.Cert)
 }

--- a/construct.go
+++ b/construct.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	instrumentationName  = "github.com/d7561985/tel"
+	instrumentationName  = "github.com/tel-io/tel"
 	ServiceNameKey       = attribute.Key("service")
 	ServiceInstanceIDKey = attribute.Key("service_instance_id")
 )

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 )
 
 require (
+	github.com/caarlos0/env/v9 v9.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/caarlos0/env/v9 v9.0.0 h1:SI6JNsOA+y5gj9njpgybykATIylrRMklbs5ch6wO6pc=
+github.com/caarlos0/env/v9 v9.0.0/go.mod h1:ye5mlCVMYh6tZ+vCgrs/B95sj88cg5Tlnc0XIzgZ020=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/logtransform/log.go
+++ b/pkg/logtransform/log.go
@@ -27,14 +27,9 @@ func Trans(res *resource.Resource, in []logskd.Log) *tracepb.ResourceLogs {
 			Attributes:   tracetransform.KeyValues(log.Attributes()),
 		}
 
-		if span := log.Span(); span != nil {
-			trID := span.SpanContext().TraceID()
-			spanID := span.SpanContext().SpanID()
-
-			v.Flags = uint32(span.SpanContext().TraceFlags())
-			v.TraceId = trID[:16]
-			v.SpanId = spanID[:8]
-		}
+		v.Flags = uint32(log.TraceFlags())
+		v.TraceId = log.TraceID()
+		v.SpanId = log.SpanID()
 
 		ss = append(ss, v)
 	}

--- a/pkg/samplers/status_traceid_ratio_sampler.go
+++ b/pkg/samplers/status_traceid_ratio_sampler.go
@@ -1,0 +1,52 @@
+package samplers
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+var errorAttributeKey = attribute.Key("error")
+
+func StatusTraceIDRatioBased(fraction float64) trace.Sampler {
+	return statusTraceIDRatioSampler{
+		traceIDRatioSampler: trace.TraceIDRatioBased(fraction),
+		description:         fmt.Sprintf("StatusTraceIDRatioBased{%g}", fraction),
+	}
+}
+
+type statusTraceIDRatioSampler struct {
+	traceIDRatioSampler trace.Sampler
+	description         string
+}
+
+func (s statusTraceIDRatioSampler) ShouldSample(p trace.SamplingParameters) trace.SamplingResult {
+	res := s.traceIDRatioSampler.ShouldSample(p)
+
+	for _, attr := range p.Attributes {
+		if attr.Key != errorAttributeKey {
+			continue
+		}
+
+		res.Decision = trace.RecordAndSample
+		return res
+	}
+
+	for _, link := range p.Links {
+		for _, attr := range link.Attributes {
+			if attr.Key != errorAttributeKey {
+				continue
+			}
+
+			res.Decision = trace.RecordAndSample
+			return res
+		}
+	}
+
+	return res
+}
+
+func (ts statusTraceIDRatioSampler) Description() string {
+	return ts.description
+}

--- a/pkg/zcore/options.go
+++ b/pkg/zcore/options.go
@@ -1,0 +1,30 @@
+package zcore
+
+import "time"
+
+type config struct {
+	SyncInterval   time.Duration
+	MaxMessageSize int
+}
+
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (o optionFunc) apply(c *config) {
+	o(c)
+}
+
+func WithMaxMessageSize(size int) Option {
+	return optionFunc(func(c *config) {
+		c.MaxMessageSize = size
+	})
+}
+
+func WithSyncInterval(interval time.Duration) Option {
+	return optionFunc(func(c *config) {
+		c.SyncInterval = interval
+	})
+}

--- a/pkg/zcore/sync_limiter.go
+++ b/pkg/zcore/sync_limiter.go
@@ -1,0 +1,35 @@
+package zcore
+
+import (
+	"sync"
+	"time"
+)
+
+func newSyncLimiter(interval time.Duration) *syncLimiter {
+	return &syncLimiter{
+		interval: interval,
+	}
+}
+
+type syncLimiter struct {
+	interval     time.Duration
+	lastSyncTime time.Time
+	mu           sync.Mutex
+}
+
+func (lim *syncLimiter) CanSync() bool {
+	if lim.interval <= 0 {
+		return true
+	}
+
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	now := time.Now()
+	canSync := now.Sub(lim.lastSyncTime) >= lim.interval
+	if canSync {
+		lim.lastSyncTime = now
+	}
+
+	return canSync
+}

--- a/pkg/ztrace/options.go
+++ b/pkg/ztrace/options.go
@@ -1,0 +1,28 @@
+package ztrace
+
+type config struct {
+	TrackLogFields  bool
+	TrackLogMessage bool
+}
+
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (o optionFunc) apply(c *config) {
+	o(c)
+}
+
+func WithTrackLogFields(b bool) Option {
+	return optionFunc(func(c *config) {
+		c.TrackLogFields = b
+	})
+}
+
+func WithTrackLogMessage(b bool) Option {
+	return optionFunc(func(c *config) {
+		c.TrackLogMessage = b
+	})
+}

--- a/pkg/ztrace/ztrace.go
+++ b/pkg/ztrace/ztrace.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tel-io/tel/v2/otlplog/logskd"
 	"github.com/tel-io/tel/v2/pkg/attrencoder"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap/zapcore"
@@ -15,25 +16,36 @@ var (
 
 type Core struct {
 	trace.Span
-	enc *attrencoder.AtrEncoder
-	lvl zapcore.Level
+	enc    *attrencoder.AtrEncoder
+	lvl    zapcore.Level
+	config *config
 }
 
-func New(lvl zapcore.Level, span trace.Span) zapcore.Core {
-	return &Core{lvl: lvl, Span: span, enc: attrencoder.NewAttr()}
+func New(lvl zapcore.Level, span trace.Span, opts ...Option) zapcore.Core {
+	c := &config{}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+
+	return &Core{
+		lvl:    lvl,
+		Span:   span,
+		enc:    attrencoder.NewAttr(),
+		config: c,
+	}
 }
 
 func (c *Core) clone() *Core {
 	return &Core{
-		Span: c.Span,
-		enc:  c.enc.Clone(),
-		lvl:  c.lvl,
+		Span:   c.Span,
+		enc:    c.enc.Clone(),
+		lvl:    c.lvl,
+		config: c.config,
 	}
 }
 
 func (c *Core) With(fields []zapcore.Field) zapcore.Core {
 	clone := c.clone()
-	//addFields(clone.enc, fields)
 
 	for i := range fields {
 		if fields[i].Key == logskd.SpanKey {
@@ -51,15 +63,21 @@ func (c *Core) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 		return errors.WithStack(ErrNotRecording)
 	}
 
-	e, err := c.enc.EncodeEntry(entry, fields)
-	if err != nil {
-		return errors.WithStack(err)
+	if c.config.TrackLogFields {
+		attrs, err := c.enc.EncodeEntry(entry, fields)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		c.Span.SetAttributes(attrs...)
 	}
 
-	c.Span.AddEvent(entry.Message)
-	c.Span.SetAttributes(e...)
+	if c.config.TrackLogMessage {
+		c.Span.AddEvent(entry.Message)
+	}
 
 	if entry.Level == zapcore.ErrorLevel {
+		c.Span.SetAttributes(attribute.Bool("error", true))
 		c.Span.SetStatus(codes.Error, "error_mark")
 	}
 


### PR DESCRIPTION
- new StatusTraceIDRatioBased sampler
- new default options (retry off, sampler: never, max log message size: 256 symbols, not track log message and fields in span, flush rate on errors 1/second)
- don't keep Span instance in LogInstance (allow gc to collect it as soon as possible)