### PR TITLE
Reduce mutex latency on log batch processor

### DIFF
--- a/otlplog/logskd/batch_processor.go
+++ b/otlplog/logskd/batch_processor.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+var _ LogProcessor = (*batchProcessor)(nil)
+
 // batchProcessor is a LogProcessor that batches asynchronously-received
 // logs and sends them to the otlplog.Exporter when complete.
 //

--- a/otlplog/logskd/batch_processor.go
+++ b/otlplog/logskd/batch_processor.go
@@ -2,7 +2,6 @@ package logskd
 
 import (
 	"context"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -12,7 +11,7 @@ import (
 )
 
 // batchProcessor is a LogProcessor that batches asynchronously-received
-// logs and sends them to a otlplog.Exporter when complete.
+// logs and sends them to the otlplog.Exporter when complete.
 //
 // some logic taken from trace.batchSpanProcessor for future telemetry compatibility
 type batchProcessor struct {
@@ -22,12 +21,15 @@ type batchProcessor struct {
 	queue   chan Log
 	dropped uint32
 
-	batch      []Log
-	batchMutex sync.Mutex
-	timer      *time.Timer
-	stopWait   sync.WaitGroup
-	stopOnce   sync.Once
-	stopCh     chan struct{}
+	batch       []Log
+	batchCh     chan struct{}
+	batchMutex  sync.Mutex
+	batchTicker *time.Ticker
+
+	pushWait sync.WaitGroup
+	stopWait sync.WaitGroup
+	stopOnce sync.Once
+	stopCh   chan struct{}
 }
 
 // NewBatchLogProcessor creates a new LogProcessor that will send completed
@@ -44,33 +46,33 @@ func NewBatchLogProcessor(exporter Exporter, options ...trace.BatchSpanProcessor
 	for _, opt := range options {
 		opt(&o)
 	}
+
 	bsp := &batchProcessor{
-		e:      exporter,
-		o:      o,
-		batch:  make([]Log, 0, o.MaxExportBatchSize),
-		timer:  time.NewTimer(o.BatchTimeout),
-		queue:  make(chan Log, o.MaxQueueSize),
-		stopCh: make(chan struct{}),
+		e:           exporter,
+		o:           o,
+		batch:       make([]Log, 0, o.MaxExportBatchSize),
+		batchTicker: time.NewTicker(o.BatchTimeout),
+		queue:       make(chan Log, o.MaxQueueSize),
+		stopCh:      make(chan struct{}),
 	}
 
-	bsp.stopWait.Add(1)
+	bsp.stopWait.Add(2)
 	go func() {
 		defer bsp.stopWait.Done()
 		bsp.processQueue()
-		bsp.drainQueue()
+	}()
+
+	go func() {
+		defer bsp.stopWait.Done()
+		bsp.processFlush(context.Background())
 	}()
 
 	return bsp
 }
 
 // Write method enqueues a ReadOnlySpan for later processing.
-func (bsp *batchProcessor) Write(s Log) {
-	// Do not enqueue spans if we are just going to drop them.
-	if bsp.e == nil {
-		return
-	}
-
-	bsp.enqueue(s)
+func (bsp *batchProcessor) Write(lo Log) {
+	bsp.enqueue(context.Background(), lo, bsp.o.BlockOnQueueFull)
 }
 
 // Shutdown flushes the queue and waits until all spans are processed.
@@ -79,16 +81,21 @@ func (bsp *batchProcessor) Shutdown(ctx context.Context) error {
 	var err error
 	bsp.stopOnce.Do(func() {
 		wait := make(chan struct{})
+
 		go func() {
 			close(bsp.stopCh)
+			bsp.pushWait.Wait()
 			bsp.stopWait.Wait()
+
 			if bsp.e != nil {
 				if err = bsp.e.Shutdown(ctx); err != nil {
 					otel.Handle(err)
 				}
 			}
+
 			close(wait)
 		}()
+
 		// Wait until the wait group is done or the context is canceled
 		select {
 		case <-wait:
@@ -100,47 +107,49 @@ func (bsp *batchProcessor) Shutdown(ctx context.Context) error {
 	return err
 }
 
-type forceFlush struct {
-	Log
-	flushed chan struct{}
-}
-
 // ForceFlush exports all ended spans that have not yet been exported.
 func (bsp *batchProcessor) ForceFlush(ctx context.Context) error {
 	var err error
-	if bsp.e != nil {
-		flushCh := make(chan struct{})
-		if bsp.enqueueBlockOnQueueFull(ctx, forceFlush{flushed: flushCh}, true) {
-			select {
-			case <-flushCh:
-				// Processed any items in queue prior to ForceFlush being called
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
 
-		wait := make(chan error)
-		go func() {
-			wait <- bsp.exportLogs(ctx)
-			close(wait)
-		}()
-		// Wait until the export is finished or the context is canceled/timed out
-		select {
-		case err = <-wait:
-		case <-ctx.Done():
-			err = ctx.Err()
-		}
+	errCh := make(chan error)
+	go func() {
+		errCh <- bsp.flushLogs(ctx)
+		close(errCh)
+	}()
+
+	// Wait until the export is finished or the context is canceled/timed out
+	select {
+	case err = <-errCh:
+	case <-ctx.Done():
+		err = ctx.Err()
 	}
 
 	return err
 }
 
 // exportLogs is a subroutine of processing and draining the queue.
-func (bsp *batchProcessor) exportLogs(ctx context.Context) error {
-	bsp.timer.Reset(bsp.o.BatchTimeout)
+func (bsp *batchProcessor) flushLogs(ctx context.Context) error {
+	if bsp.e == nil {
+		return nil
+	}
 
 	bsp.batchMutex.Lock()
-	defer bsp.batchMutex.Unlock()
+
+	if len(bsp.batch) == 0 {
+		bsp.batchMutex.Unlock()
+		return nil
+	}
+
+	batch := make([]Log, len(bsp.batch))
+	copy(batch, bsp.batch)
+
+	// A new batch is always created after exporting, even if the batch failed to be exported.
+	//
+	// It is up to the exporter to implement any type of retry logic if a batch is failing
+	// to be exported, since it is specific to the protocol and backend being sent to.
+	bsp.batch = bsp.batch[:0]
+
+	bsp.batchMutex.Unlock()
 
 	if bsp.o.ExportTimeout > 0 {
 		var cancel context.CancelFunc
@@ -148,111 +157,52 @@ func (bsp *batchProcessor) exportLogs(ctx context.Context) error {
 		defer cancel()
 	}
 
-	if l := len(bsp.batch); l > 0 {
-		err := bsp.e.ExportLogs(ctx, bsp.batch)
+	return bsp.e.ExportLogs(ctx, batch)
+}
 
-		// A new batch is always created after exporting, even if the batch failed to be exported.
-		//
-		// It is up to the exporter to implement any type of retry logic if a batch is failing
-		// to be exported, since it is specific to the protocol and backend being sent to.
-		bsp.batch = bsp.batch[:0]
+func (bsp *batchProcessor) processFlush(ctx context.Context) {
+	for {
+		select {
+		case <-bsp.stopCh:
+			bsp.batchTicker.Stop()
+			return
+		case <-bsp.batchCh:
+		case <-bsp.batchTicker.C:
+		}
 
-		if err != nil {
-			return err
+		if err := bsp.flushLogs(ctx); err != nil {
+			otel.Handle(err)
 		}
 	}
-
-	return nil
 }
 
 // processQueue removes spans from the `queue` channel until processor
 // is shut down. It calls the exporter in batches of up to MaxExportBatchSize
 // waiting up to BatchTimeout to form a batch.
 func (bsp *batchProcessor) processQueue() {
-	defer bsp.timer.Stop()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	for {
 		select {
 		case <-bsp.stopCh:
 			return
-		case <-bsp.timer.C:
-			if err := bsp.exportLogs(ctx); err != nil {
-				otel.Handle(err)
-			}
-		case sd := <-bsp.queue:
-			if ffs, ok := sd.(forceFlush); ok {
-				close(ffs.flushed)
-
-				continue
-			}
+		case lo := <-bsp.queue:
 			bsp.batchMutex.Lock()
-			bsp.batch = append(bsp.batch, sd)
-			shouldExport := len(bsp.batch) >= bsp.o.MaxExportBatchSize
-			bsp.batchMutex.Unlock()
-			if shouldExport {
-				if !bsp.timer.Stop() {
-					<-bsp.timer.C
-				}
-				if err := bsp.exportLogs(ctx); err != nil {
-					otel.Handle(err)
+			bsp.batch = append(bsp.batch, lo)
+
+			if len(bsp.batch) >= bsp.o.MaxExportBatchSize {
+				select {
+				case bsp.batchCh <- struct{}{}:
+				default:
 				}
 			}
+
+			bsp.batchMutex.Unlock()
 		}
 	}
 }
 
-// drainQueue awaits the any caller that had added to bsp.stopWait
-// to finish the enqueue, then exports the final batch.
-func (bsp *batchProcessor) drainQueue() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	for {
-		select {
-		case sd := <-bsp.queue:
-			if sd == nil {
-				if err := bsp.exportLogs(ctx); err != nil {
-					otel.Handle(err)
-				}
-				return
-			}
-
-			bsp.batchMutex.Lock()
-			bsp.batch = append(bsp.batch, sd)
-			shouldExport := len(bsp.batch) == bsp.o.MaxExportBatchSize
-			bsp.batchMutex.Unlock()
-
-			if shouldExport {
-				if err := bsp.exportLogs(ctx); err != nil {
-					otel.Handle(err)
-				}
-			}
-		default:
-			close(bsp.queue)
-		}
-	}
-}
-
-func (bsp *batchProcessor) enqueue(sd Log) {
-	bsp.enqueueBlockOnQueueFull(context.TODO(), sd, bsp.o.BlockOnQueueFull)
-}
-
-func (bsp *batchProcessor) enqueueBlockOnQueueFull(ctx context.Context, sd Log, block bool) bool {
-	// This ensures the bsp.queue<- below does not panic as the
-	// processor shuts down.
-	defer func() {
-		x := recover()
-		switch err := x.(type) {
-		case nil:
-			return
-		case runtime.Error:
-			if err.Error() == "send on closed channel" {
-				return
-			}
-		}
-		panic(x)
-	}()
+func (bsp *batchProcessor) enqueue(ctx context.Context, lo Log, block bool) bool {
+	bsp.pushWait.Add(1)
+	defer bsp.pushWait.Done()
 
 	select {
 	case <-bsp.stopCh:
@@ -262,7 +212,7 @@ func (bsp *batchProcessor) enqueueBlockOnQueueFull(ctx context.Context, sd Log, 
 
 	if block {
 		select {
-		case bsp.queue <- sd:
+		case bsp.queue <- lo:
 			return true
 		case <-ctx.Done():
 			return false
@@ -270,10 +220,11 @@ func (bsp *batchProcessor) enqueueBlockOnQueueFull(ctx context.Context, sd Log, 
 	}
 
 	select {
-	case bsp.queue <- sd:
+	case bsp.queue <- lo:
 		return true
 	default:
 		atomic.AddUint32(&bsp.dropped, 1)
 	}
+
 	return false
 }


### PR DESCRIPTION
I've moved export log process to it's own routine that will start export by signal on channel or ticker. Reduce mutex impact on system. Previously all routines (theoretically all handlers in http server) had to wait until export finished.